### PR TITLE
282 Fix sendKeysLoop

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/elements/Element.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/Element.java
@@ -305,7 +305,7 @@ public class Element {
 			return true;
 		} 
 		catch (WebDriverException e) {
-			if(!element.isEnabled()) { // Respect if an element is disabled.
+			if(!element().isEnabled()) { // Respect if an element is disabled.
 				var errorMessage = SentinelStringUtils.format(
 						"{} element named \"{}\" is disabled and cannot receive text. The selectors being used are: {}"
 							, elementType
@@ -317,6 +317,7 @@ public class Element {
 				JavascriptExecutor jse = (JavascriptExecutor) driver();
 				jse.executeScript("arguments[0].value='" + text + "';", element());
 
+				element = element();
 				constructElementWait(Time.loopInterval())
 						.until(ExpectedConditions.textToBePresentInElementValue(element, text));
 


### PR DESCRIPTION
Closing #282 
Change to sendKeysLoop in Element.java to prevent uncaught StaleElementReferenceException.

- update reference to element after interactions in sendKeysLoop in case element changes / reloads after these interactions to prevent uncaught StaleElementReferenceException