### PR TITLE
add method for switching to parent window

### DIFF
--- a/docs/test/table.html
+++ b/docs/test/table.html
@@ -2,42 +2,46 @@
 <head></head>
 <body>
 	<table id="mytable">
-		<tr>
-			<th>ID</th>
-			<th>First Name</th>
-			<th>Last Name</th>
-			<th>City</th>
-			<th>Zip Code</th>
-			<th>Distance</th>
-			<th>ID Number</th>
-		</tr>
-		<tr>
-			<td>1</td>
-			<td>Bob</td>
-			<td>Smith</td>
-			<td>Windypeaks</td>
-			<td>29401</td>
-			<td>3.1 Miles</td>
-			<td>A1356</td>
-		</tr>
-		<tr>
-			<td>2</td>
-			<td>Charlotte</td>
-			<td>Smith</td>
-			<td>Lilac Bay</td>
-			<td>12111</td>
-			<td>10.11 Miles</td>
-			<td>11234</td>
-		</tr>
-		<tr>
-			<td>2</td>
-			<td id="Dave">Dave</td>
-			<td>Smith</td>
-			<td>Boston</td>
-			<td>02111</td>
-			<td>10.45 Miles</td>
-			<td>304</td>
-		</tr>
+		<thead>
+			<tr>
+				<th>ID</th>
+				<th>First Name</th>
+				<th>Last Name</th>
+				<th>City</th>
+				<th>Zip Code</th>
+				<th>Distance</th>
+				<th>ID Number</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>1</td>
+				<td>Bob</td>
+				<td>Smith</td>
+				<td>Windypeaks</td>
+				<td>29401</td>
+				<td>3.1 Miles</td>
+				<td>A1356</td>
+			</tr>
+			<tr>
+				<td>2</td>
+				<td>Charlotte</td>
+				<td>Smith</td>
+				<td>Lilac Bay</td>
+				<td>12111</td>
+				<td>10.11 Miles</td>
+				<td>11234</td>
+			</tr>
+			<tr>
+				<td>2</td>
+				<td id="Dave">Dave</td>
+				<td>Smith</td>
+				<td>Boston</td>
+				<td>02111</td>
+				<td>10.45 Miles</td>
+				<td>304</td>
+			</tr>
+		</tbody>
 	</table>
 </body>
 </html>

--- a/docs/test/table.html
+++ b/docs/test/table.html
@@ -2,46 +2,42 @@
 <head></head>
 <body>
 	<table id="mytable">
-		<thead>
-			<tr>
-				<th>ID</th>
-				<th>First Name</th>
-				<th>Last Name</th>
-				<th>City</th>
-				<th>Zip Code</th>
-				<th>Distance</th>
-				<th>ID Number</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td>1</td>
-				<td>Bob</td>
-				<td>Smith</td>
-				<td>Windypeaks</td>
-				<td>29401</td>
-				<td>3.1 Miles</td>
-				<td>A1356</td>
-			</tr>
-			<tr>
-				<td>2</td>
-				<td>Charlotte</td>
-				<td>Smith</td>
-				<td>Lilac Bay</td>
-				<td>12111</td>
-				<td>10.11 Miles</td>
-				<td>11234</td>
-			</tr>
-			<tr>
-				<td>2</td>
-				<td id="Dave">Dave</td>
-				<td>Smith</td>
-				<td>Boston</td>
-				<td>02111</td>
-				<td>10.45 Miles</td>
-				<td>304</td>
-			</tr>
-		</tbody>
+		<tr>
+			<th>ID</th>
+			<th>First Name</th>
+			<th>Last Name</th>
+			<th>City</th>
+			<th>Zip Code</th>
+			<th>Distance</th>
+			<th>ID Number</th>
+		</tr>
+		<tr>
+			<td>1</td>
+			<td>Bob</td>
+			<td>Smith</td>
+			<td>Windypeaks</td>
+			<td>29401</td>
+			<td>3.1 Miles</td>
+			<td>A1356</td>
+		</tr>
+		<tr>
+			<td>2</td>
+			<td>Charlotte</td>
+			<td>Smith</td>
+			<td>Lilac Bay</td>
+			<td>12111</td>
+			<td>10.11 Miles</td>
+			<td>11234</td>
+		</tr>
+		<tr>
+			<td>2</td>
+			<td id="Dave">Dave</td>
+			<td>Smith</td>
+			<td>Boston</td>
+			<td>02111</td>
+			<td>10.45 Miles</td>
+			<td>304</td>
+		</tr>
 	</table>
 </body>
 </html>

--- a/src/main/java/com/dougnoel/sentinel/elements/tables/Table.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/tables/Table.java
@@ -36,7 +36,7 @@ public class Table extends Element {
 	protected String tableRowTag = "tr";
 	protected String tableCellDataTag = "td";
 	protected String tableDataCellLocator = "//" + tableCellDataTag;
-	protected String tableRowLocator = ".//tbody//" + tableRowTag;
+	protected String tableRowLocator = ".//tbody//" + tableCellDataTag + "/..";
 	protected String tableSiblingCellLocator = "//..//*";
 	
 	/**

--- a/src/main/java/com/dougnoel/sentinel/elements/tables/Table.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/tables/Table.java
@@ -196,10 +196,9 @@ public class Table extends Element {
 	 * @return int the number of row elements
 	 */
 	public int getNumberOfRows() {
-		//Selenium counts a <th> tag as a <td> tag and returns it.
 		final int numberOfRows = getOrCreateRowElements().size();
 		log.trace("Number of rows found: {}", numberOfRows);
-		return numberOfRows - 1;
+		return numberOfRows;
 	}
 
 	/**

--- a/src/main/java/com/dougnoel/sentinel/pages/PageManager.java
+++ b/src/main/java/com/dougnoel/sentinel/pages/PageManager.java
@@ -245,16 +245,17 @@ public class PageManager {
 		WebDriverFactory.close();
 		return switchToParentWindow();
 	}
-	
+
 	/**
 	 * Switches to the parent window without closing the child window.
+	 * 
 	 * @return String the handle of the parent window to which we are returning
 	 * @throws InterruptedException
 	 */
 	public static String switchToParentWindow() throws InterruptedException {
 		driver().switchTo().window(parentHandle);
-        setPage(parentPage);
-        waitForPageLoad();
+		setPage(parentPage);
+		waitForPageLoad();
 		return parentHandle;
 	}
 

--- a/src/main/java/com/dougnoel/sentinel/pages/PageManager.java
+++ b/src/main/java/com/dougnoel/sentinel/pages/PageManager.java
@@ -243,6 +243,15 @@ public class PageManager {
 	 */
 	public static String closeChildWindow() throws InterruptedException {
 		WebDriverFactory.close();
+		return switchToParentWindow();
+	}
+	
+	/**
+	 * Switches to the parent window without closing the child window.
+	 * @return String the handle of the parent window to which we are returning
+	 * @throws InterruptedException
+	 */
+	public static String switchToParentWindow() throws InterruptedException {
 		driver().switchTo().window(parentHandle);
         setPage(parentPage);
         waitForPageLoad();

--- a/src/main/java/com/dougnoel/sentinel/steps/TableVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/TableVerificationSteps.java
@@ -36,7 +36,7 @@ public class TableVerificationSteps {
      * @param expectedNumberOfRows int The number of rows your are expecting.
      * @param elementName String (Table name) This should be the name of the table element to count.
      */
-    @Then("^I see (\\d+) row(?:s)? in the (.*)$")
+    @Then("^I see (\\d+) rows? in the (.*)$")
     public static void verifyNumberOfTableRows(int expectedNumberOfRows, String elementName) {
         int numberOfRows = getElementAsTable(elementName).getNumberOfRows();
         var expectedResult = SentinelStringUtils.format("Expected {} rows, found {} rows.", expectedNumberOfRows, numberOfRows);

--- a/src/main/java/com/dougnoel/sentinel/steps/TableVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/TableVerificationSteps.java
@@ -36,7 +36,7 @@ public class TableVerificationSteps {
      * @param expectedNumberOfRows int The number of rows your are expecting.
      * @param elementName String (Table name) This should be the name of the table element to count.
      */
-    @Then("^I see (\\d+) rows in the (.*)$")
+    @Then("^I see (\\d+) row(?:s)? in the (.*)$")
     public static void verifyNumberOfTableRows(int expectedNumberOfRows, String elementName) {
         int numberOfRows = getElementAsTable(elementName).getNumberOfRows();
         var expectedResult = SentinelStringUtils.format("Expected {} rows, found {} rows.", expectedNumberOfRows, numberOfRows);


### PR DESCRIPTION
fixing #295 
- Add method for switching to parent window without closing current window. For use in the case that some other browser action has already closed the child window, or if the user wants to leave a child window open.