### PR TITLE
Fix 367

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/system/FileManager.java
+++ b/src/main/java/com/dougnoel/sentinel/system/FileManager.java
@@ -100,7 +100,7 @@ public class FileManager {
 	public static String getClassPath(String className) {
 		try {
 			String filePath = findFilePath(className + ".java").getPath();
-			String returnValue = convertPathSeparators(StringUtils.removeEnd(filePath, ".java"));
+			String returnValue = StringUtils.removeEnd(filePath, ".java").replace(File.separator, ".");
 			return StringUtils.substringAfter(returnValue, "java.");
 		} catch (FileException fe) {
 			return null;


### PR DESCRIPTION
Fix #367 
revert breaking change to filemanager.getclasspath() in order to properly fetch custom element type class paths.