### PR TITLE
Tybou/wait until stored text

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/elements/Element.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/Element.java
@@ -625,9 +625,13 @@ public class Element {
 	 * @return Boolean If the text value was found in the element.
 	 */
 	public Boolean waitForText(String text, boolean present) {
-		ExpectedCondition<Boolean> condition = ExpectedConditions.textToBePresentInElement(element(), text);
+		ExpectedCondition<Boolean> condition  = ExpectedConditions.or(
+				ExpectedConditions.textToBePresentInElement(element(), text),
+				ExpectedConditions.textToBePresentInElementValue(element(), text)
+		);
+
 		if (!present)
-			condition = ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(element(), text));
+			condition = ExpectedConditions.not(condition);
 
 		long searchTime = Time.out().getSeconds() * 1000;
 		long startTime = System.currentTimeMillis(); // fetch starting time

--- a/src/main/java/com/dougnoel/sentinel/elements/Textbox.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/Textbox.java
@@ -35,31 +35,4 @@ public class Textbox extends Element {
 	public String getText() {
 		return element().getAttribute("value");
 	}
-
-	/**
-	 * Waits until the text contains a certain value, and returns if it was found
-	 *
-	 * @return Boolean If the text value was found in the element.
-	 */
-	@Override
-	public Boolean waitForText(String text, boolean present) {
-		ExpectedCondition<Boolean> condition = ExpectedConditions.textToBePresentInElementValue(element(), text);
-		if (!present)
-			condition = ExpectedConditions.not(ExpectedConditions.textToBePresentInElementValue(element(), text));
-
-		long searchTime = Time.out().getSeconds() * 1000;
-		long startTime = System.currentTimeMillis(); // fetch starting time
-
-		while ((System.currentTimeMillis() - startTime) < searchTime) {
-			try {
-				return new WebDriverWait(Driver.getWebDriver(), Time.interval().toMillis(), Time.loopInterval().toMillis())
-						.ignoring(StaleElementReferenceException.class)
-						.ignoring(TimeoutException.class)
-						.until(condition);
-			} catch (TimeoutException e) {
-				// suppressing this due to falsely thrown timeout exception
-			}
-		}
-		return false;
-	}
 }

--- a/src/main/java/com/dougnoel/sentinel/elements/Textbox.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/Textbox.java
@@ -1,5 +1,13 @@
 package com.dougnoel.sentinel.elements;
 
+import com.dougnoel.sentinel.configurations.Time;
+import com.dougnoel.sentinel.webdrivers.Driver;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
 import java.util.Map;
 
 /**
@@ -26,5 +34,32 @@ public class Textbox extends Element {
 	@Override
 	public String getText() {
 		return element().getAttribute("value");
+	}
+
+	/**
+	 * Waits until the text contains a certain value, and returns if it was found
+	 *
+	 * @return Boolean If the text value was found in the element.
+	 */
+	@Override
+	public Boolean waitForText(String text, boolean present) {
+		ExpectedCondition<Boolean> condition = ExpectedConditions.textToBePresentInElementValue(element(), text);
+		if (!present)
+			condition = ExpectedConditions.not(ExpectedConditions.textToBePresentInElementValue(element(), text));
+
+		long searchTime = Time.out().getSeconds() * 1000;
+		long startTime = System.currentTimeMillis(); // fetch starting time
+
+		while ((System.currentTimeMillis() - startTime) < searchTime) {
+			try {
+				return new WebDriverWait(Driver.getWebDriver(), Time.interval().toMillis(), Time.loopInterval().toMillis())
+						.ignoring(StaleElementReferenceException.class)
+						.ignoring(TimeoutException.class)
+						.until(condition);
+			} catch (TimeoutException e) {
+				// suppressing this due to falsely thrown timeout exception
+			}
+		}
+		return false;
 	}
 }

--- a/src/main/java/com/dougnoel/sentinel/steps/TextSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/TextSteps.java
@@ -16,34 +16,48 @@ import io.cucumber.java.en.When;
 public class TextSteps {
 
 	/**
-     * Appends random text to the given text and enters this new text into a text box that matches the given elementName
-     * as defined on the Page object. The given element name is made lower  case and whitespaces are replaced with underscores,
+     * Appends or prepends random alphanumeric text or unique system time in milliseconds
+     * to the given text and enters this new text into a text box that matches the given elementName
+     * as defined on the Page object. The given element name is made lower-case and whitespaces are replaced with underscores,
      * then it is sent a sendKeys event to an element defined on a page object with that name. The
      * page object and driver object are defined by the WebDriverFactory and PageFactory objects.
      * The derived Page Object (extends Page) should define a method named [element name]_[element type]
      * returning a Element object (e.g. password_field).
-     * <p>
+     * <br><br>
      * Since this random value might need to be referenced again, we store it using
      * the ConfigurationManager, using the passed elementname as the key to retrieve
      * it.
-     * <p>
+     * <br><br>
+     * <b>Note:</b> You can optionally specify <b>uniquely</b> rather than <b>randomly</b> to append/prepend
+     * the current system time in milliseconds to the given text.
+     * <br><br>
      * <b>Gherkin Examples:</b>
      * <ul>
-     * <li>I enter random User Name Bob in the username textbox</li>
-     * <li>I enter random text in the Street Address field</li>
+     * <li>I <u>randomly</u> <u>enter</u> <u>random User Name Bob</u> in the <u>username textbox</u></li>
+     * <li>I <u>randomly</u> <u>append</u> to <u>random User Name Bob</u> in the <u>username textbox</u></li>
+     * <li>I <u>randomly</u> <u>prepend</u> to <u>@gmail.com</u> in the <u>Email Field</u></li>
+     * <li>I <u>uniquely</u> <u>prepend</u> <u>@gmail.com</u> in the <u>Email Field</u></li>
      * </ul>
-     * 
+     *
+     * @param operation String whether to enter/append or prepend randomly to the given text
      * @param text String the text to enter into the element
-     * @param elementName String the name of the element into which to enter text
-     * @param storageName String an additional modifier for storing data
+     * @param elementName String the name of the element into which to enter text, and the name to store the text under
      */
-    @When("^I randomly enter (.*) in the (.*)(?: for the (.*))$")
-    public static void enterRandomText(String text, String elementName, String storageName) {
-        text = text + RandomStringUtils.randomAlphanumeric(16);
+    @When("^I (randomly|uniquely) (enter|append|prepend)(?: to)? (.*) in the (.*)$")
+    public static void enterRandomText(String alphanumericOrNumeric, String operation, String text, String elementName) {
+        String randomCharacters;
+
+        if(alphanumericOrNumeric.equals("randomly"))
+            randomCharacters = RandomStringUtils.randomAlphanumeric(16);
+        else
+            randomCharacters = Long.toString(System.currentTimeMillis());
+
+        if(operation.contains("prepend"))
+            text = randomCharacters + text;
+        else
+            text = text + randomCharacters;
+
         enterText(text, elementName);
-        if (storageName != null) {
-            elementName = storageName + " " + elementName;
-        }
         Configuration.update(elementName, text);
     }
 

--- a/src/main/java/com/dougnoel/sentinel/steps/TextVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/TextVerificationSteps.java
@@ -99,7 +99,24 @@ public class TextVerificationSteps {
             }
         }
     }
-    
+
+    @Then("^I wait until the (.*?)( does not)? contains? the text (?:entered|used) (?:for|in) the (.*?)$")
+    public static void waitUntilElementTextContainsStored(String elementName, String assertion, String key) {
+        boolean negate = !StringUtils.isEmpty(assertion);
+        String negateText = negate ? "not " : "";
+        var textToMatch = Configuration.toString(key);
+
+        boolean found = getElement(elementName).waitForText(textToMatch, (!negate));
+        String elementText = getElement(elementName).getText();
+
+        var expectedResult = SentinelStringUtils.format(
+                "Expected the {} element to {}contain the text \"{}\" stored in the configuration key {}. The element contained the text: \"{}\"",
+                elementName, negateText, textToMatch, key, elementText);
+
+        assertTrue(expectedResult, found);
+    }
+
+
     /**
      * Waits until we can verify that an element contains certain text. It uses the text
      * contained in double quotes for matching. If the condition is not true, it will wait 
@@ -128,7 +145,6 @@ public class TextVerificationSteps {
             
         log.trace(expectedResult);
         assertTrue(expectedResult, found);
-
     }
     
     /**

--- a/src/main/java/com/dougnoel/sentinel/steps/TextVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/TextVerificationSteps.java
@@ -100,6 +100,22 @@ public class TextVerificationSteps {
         }
     }
 
+    /**
+     * <p>
+     * Waits until we can verify that an element contains text stored previously.
+     * Such as by steps that randomly append/prepend to text.
+     * </p>
+     * <b>Gherkin Examples:</b>
+     * <ul>
+     * <li>I wait until the <u>Last Name Field</u> contains the text entered for the <u>Last Name Field</u></li>
+     * <li>I wait until the <u>Username Display</u> contains the text used in the <u>User Name Input Field</u></li>
+     * <li>I wait until the <u>Last Name Field</u> <u>does not</u> contain the text entered for the <u>First Name Field</u></li>
+     * </ul>
+     *
+     * @param elementName String The name of the element to be evaluated as defined in the page object.
+     * @param assertion String whether or not we expect a match or mismatch
+     * @param key String the storage key for the previously stored text to check for
+     */
     @Then("^I wait until the (.*?)( does not)? contains? the text (?:entered|used) (?:for|in) the (.*?)$")
     public static void waitUntilElementTextContainsStored(String elementName, String assertion, String key) {
         boolean negate = !StringUtils.isEmpty(assertion);

--- a/src/test/java/com/saucelabs/GuineaPigPage.yml
+++ b/src/test/java/com/saucelabs/GuineaPigPage.yml
@@ -19,7 +19,12 @@ elements:
   your_comments_span:
     elementType: Span
     id: "your_comments"
+  email_text_area:
+    elementType: TextBox
+    id: "fbemail"
+    name: "fbemail"
   comments_text_area:
+    elementType: TextBox
     id: "comments"
     name: "comments"
   send_button:

--- a/src/test/java/features/Text Tests.feature
+++ b/src/test/java/features/Text Tests.feature
@@ -14,7 +14,7 @@ Feature: Text Verifcation Tests
   	Then I verify the username field is empty  
   	When I fill the account information into the username field and the password field
   	  And I enter Bob in the username field
-  	  And I randomly enter text in the password field for the fun of it
+  	  And I randomly enter text in the password field
   	  And I reuse the password field text in the password field
   	Then I verify the username field is not empty
   	  And I verify the username field does not contain the text "foo"
@@ -22,3 +22,18 @@ Feature: Text Verifcation Tests
   	When I press the browser back button
   	  And I press the browser forward button
   	  And I press the browser refresh button
+
+	@text
+	Scenario: I randomly append/prepend/enter text, and verify the entry
+		Given I am on the Textbox Page
+		When I randomly enter test in the Last Name Field
+		Then I wait until the Last Name Field contains the text entered for the Last Name Field
+		When I clear the Last Name Field
+		  And I uniquely enter test in the Last Name Field
+		Then I wait until the Last Name Field contains the text used for the Last Name Field
+		When I clear the Last Name Field
+			And I randomly prepend @gmail.com in the Last Name Field
+		Then I wait until the Last Name Field contains the text entered in the Last Name Field
+		When I clear the Last Name Field
+			And I randomly append to @gmail.com in the Last Name Field
+		Then I wait until the Last Name Field contains the text used in the Last Name Field

--- a/src/test/java/features/Text Tests.feature
+++ b/src/test/java/features/Text Tests.feature
@@ -25,15 +25,19 @@ Feature: Text Verifcation Tests
 
 	@text
 	Scenario: I randomly append/prepend/enter text, and verify the entry
-		Given I am on the Textbox Page
-		When I randomly enter test in the Last Name Field
-		Then I wait until the Last Name Field contains the text entered for the Last Name Field
-		When I clear the Last Name Field
-		  And I uniquely enter test in the Last Name Field
-		Then I wait until the Last Name Field contains the text used for the Last Name Field
-		When I clear the Last Name Field
-			And I randomly prepend @gmail.com in the Last Name Field
-		Then I wait until the Last Name Field contains the text entered in the Last Name Field
-		When I clear the Last Name Field
-			And I randomly append to @gmail.com in the Last Name Field
-		Then I wait until the Last Name Field contains the text used in the Last Name Field
+		Given I am on the Guinea Pig Page
+		When I randomly enter test in the Comments Text Area
+			And I click the Send Button
+		Then I wait until the Your Comments Span contains the text entered for the Comments Text Area
+		When I clear the Comments Text Area
+		  And I uniquely enter test in the Comments Text Area
+			And I click the Send Button
+		Then I wait until the Your Comments Span contains the text entered for the Comments Text Area
+		When I clear the Comments Text Area
+			And I randomly prepend @gmail.com in the Email Text Area
+		Then I wait until the Email Text Area contains the text entered in the Email Text Area
+		When I clear the Comments Text Area
+			And I randomly append to @gmail.com in the Comments Text Area
+			And I click the Send Button
+			And I wait until the Comments Text Area contains the text used in the Comments Text Area
+		Then I wait until the Comments Text Area does not contain the text used in the Email Text Area


### PR DESCRIPTION
-Modified waitfortext to support value as well for elements that use value for display text (textboxes, etc)
-Modified the random enter text to support true random and sequential unique as well as append/prepend functionality and storing using the element name*
-Added wait until text contains stored text (Might be able to be merged with the other text contains, but I'll need some help with that cucumber regex. Cheat sheet would be fantastic if anyone has a good one)
-Added elements to guinea pig page for testing
-Added test coverage for the new random operation, and modified the old

***Note, we should make this change well known as the step had to be modified to make more sense. We may be able to support the old method as well, but we'll need a unique selector that can exclude "For the" in the before and after match or optionally everything at the end without for the.

If this is desired I can look into it more.**