### PR TITLE
Tyler/backspace error message fixes

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/steps/SelectVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/SelectVerificationSteps.java
@@ -78,9 +78,10 @@ public class SelectVerificationSteps {
     public static void verifyDropdownHasNumberOfOptions(String elementName, String assertion, int numberOfOptions) {
     	var dropdown = (SelectElement)getElement(elementName);
     	var negate = !assertion.contains("has");
-    	String expectedResult = SentinelStringUtils.format("Expected the element {} to {}have {} option{}.",
-                elementName, (negate ? "not " : ""), numberOfOptions, (numberOfOptions > 1 ? "s" : ""));
-		var actualResult = dropdown.getNumberOfOptions() == numberOfOptions;
+        var actualOptionCount = dropdown.getNumberOfOptions();
+    	String expectedResult = SentinelStringUtils.format("Expected the element {} to {}have {} option{}, but had {} option{}",
+                elementName, (negate ? "not " : ""), numberOfOptions, (numberOfOptions > 1 ? "s" : ""), actualOptionCount, (actualOptionCount > 1 ? "s" : ""));
+		var actualResult = actualOptionCount == numberOfOptions;
     	
     	if (negate) {
             assertFalse(expectedResult, actualResult);

--- a/src/main/java/com/dougnoel/sentinel/steps/TableVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/TableVerificationSteps.java
@@ -117,7 +117,8 @@ public class TableVerificationSteps {
     @Then("^I verify the (.*?) column in the (.*?) contains the same text (?:entered|selected|used) for the (.*)$")
     public static void verifyStoredTextAppearsInColumn(String columnName, String tableName, String key) {
     	var textToMatch = Configuration.toString(key);
-        assertTrue(getElementAsTable(tableName).verifyAnyColumnCellContains(columnName, textToMatch));
+        String errorMessage = SentinelStringUtils.format("Expected the {} column of the {} to contain any cells with the text {}", columnName, tableName, textToMatch);
+        assertTrue(errorMessage, getElementAsTable(tableName).verifyAnyColumnCellContains(columnName, textToMatch));
     }
     
     /**
@@ -138,7 +139,7 @@ public class TableVerificationSteps {
         boolean negate = !StringUtils.isEmpty(assertion);
         
         var expectedResult = SentinelStringUtils.format(
-                "Expected the {} column of the {} to {}only contain cells with the text {}. The element contained the text: {}",
+                "Expected the {} column of the {} to {}only contain cells with the text {}.",
                 columnName, tableName, (negate ? "not " : ""), textToMatch);
         log.trace(expectedResult);
 

--- a/src/main/java/com/dougnoel/sentinel/steps/TextSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/TextSteps.java
@@ -110,7 +110,7 @@ public class TextSteps {
     }
 
     /**
-     * Sends a key press event for a special key: ESCAPE, ENTER, RETURN, or TAB.
+     * Sends a key press event for a special key: BACKSPACE, ESCAPE, ENTER, RETURN, or TAB.
      * @param keyName
      * <p>
      * <b>Gherkin Examples:</b>
@@ -120,16 +120,19 @@ public class TextSteps {
      * <li>I press the tab key</li>
      * </ul>
      */
-    @When("^I press the (escape|enter|return|tab) key$")
+    @When("^I press the (backspace|escape|enter|return|tab) key$")
     public static void keyPress(String keyName) {
-    	keyName = keyName.toUpperCase();
+        if(keyName.equals("backspace"))
+            keyName = "BACK_SPACE";
+        else
+            keyName = keyName.toUpperCase();
     	var driver = Driver.getWebDriver();
         WebElement element = driver.findElement(By.tagName("Body"));
         element.sendKeys(Keys.valueOf(keyName));
     }
 
     /**
-     * Sends a key press event for a special key: ESCAPE, ENTER, RETURN, or TAB to a given element.
+     * Sends a key press event for a special key: BACKSPACE, ESCAPE, ENTER, RETURN, or TAB to a given element.
      * @param keyName
      * <p>
      * <b>Gherkin Examples:</b>
@@ -138,9 +141,12 @@ public class TextSteps {
      * <li>I press the enter key in the search box</li>
      * </ul>
      */
-    @When("^I press the (escape|enter|return|tab) key (?:to|on|in) the (.*)$")
+    @When("^I press the (backspace|escape|enter|return|tab) key (?:to|on|in) the (.*)$")
     public static void keyPressElement(String keyName, String element) {
-        keyName = keyName.toUpperCase();
+        if(keyName.equals("backspace"))
+            keyName = "BACK_SPACE";
+        else
+            keyName = keyName.toUpperCase();
         Element targetElement = getElement(element);
         targetElement.sendSpecialKey(Keys.valueOf(keyName));
     }


### PR DESCRIPTION
Added support for backspace (had to be a bit more uniquely changed as backspace is "BACK_SPACE" in the key enum which didn't seem to match the more commonly used "backspace".

Fixed an error message, and added an error message.