### PR TITLE
Adding a .Strip to remove the white spaces when searching the column …

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/elements/tables/Table.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/tables/Table.java
@@ -87,7 +87,7 @@ public class Table extends Element {
 		if (headers.isEmpty()) {
 			getOrCreateHeaderElements();
 			for (WebElement header : headerElements) {
-				String headerText = header.getText().replaceAll("[\\t\\n\\r]+"," ");
+				String headerText = header.getText().replaceAll("[\\t\\n\\r]+"," ").strip();
 				headers.add(headerText);
 			}
 		}


### PR DESCRIPTION
Added a .strip() to strip out the white spaces when searching for the column headers.  Also ran the Table Tests.feature that all passed.