### PR TITLE
Add support for the chromium browser.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,6 +41,8 @@ jobs:
       run: |
        chmod +x ./src/test/resources/scripts/InstallChrome.sh
         ./src/test/resources/scripts/InstallChrome.sh
+    - name: Install Chromium
+      run: choco install --no-progress -y chromium
     - name: Build with Maven and Analyze with Sonar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/src/main/java/com/dougnoel/sentinel/webdrivers/WebDriverFactory.java
+++ b/src/main/java/com/dougnoel/sentinel/webdrivers/WebDriverFactory.java
@@ -65,6 +65,9 @@ public class WebDriverFactory {
         case "chrome":
         	driver = createChromeDriver();
             break;
+        case "chromium":
+            driver = createChromiumDriver();
+            break;
         case "edge":
         	WebDriverManager.edgedriver().setup();
         	driver = new EdgeDriver();
@@ -133,29 +136,48 @@ public class WebDriverFactory {
         chromePrefs.put("download.default_directory", DownloadManager.getDownloadDirectory());
         options.setExperimentalOption("prefs", chromePrefs);
     }
-    
+
     /**
-     * Creates a ChromeDriver. Makes it headless if the -Dheadless flag is set.
-     * Can pass additional arguments with the -DchromeOptions flag, such as -DchromeOptions="start-maximized" to open all browser windows maximized.
-     * @return WebDriver ChromeDrvier
+     * Creates ChromeOptions for use in the chrome and chromium driver.
+     * @return ChromeOptions
      */
-    private static WebDriver createChromeDriver() {
-    	var chromeOptions = new ChromeOptions();
-    	setChromeDownloadDirectory(chromeOptions);
+    private static ChromeOptions createChromeOptions()  {
+        var chromeOptions = new ChromeOptions();
+        setChromeDownloadDirectory(chromeOptions);
         String commandlineOptions = Configuration.toString("chromeOptions");
         if (commandlineOptions != null)
             chromeOptions.addArguments(commandlineOptions);
-    	var headless = Configuration.toString("headless");
-    	if (headless != null && !headless.equalsIgnoreCase("false")) {
-    		chromeOptions.addArguments("--no-sandbox");
-    		chromeOptions.addArguments("--disable-dev-shm-usage");
-    		chromeOptions.addArguments("--headless");        		
-    	}
-    	var binary = Configuration.toString("chromeBrowserBinary");
-    	if (binary != null)
-    		chromeOptions.setBinary(binary);
+        var headless = Configuration.toString("headless");
+        if (headless != null && !headless.equalsIgnoreCase("false")) {
+            chromeOptions.addArguments("--no-sandbox");
+            chromeOptions.addArguments("--disable-dev-shm-usage");
+            chromeOptions.addArguments("--headless");
+        }
+        var binary = Configuration.toString("chromeBrowserBinary");
+        if (binary != null)
+            chromeOptions.setBinary(binary);
+
+        return chromeOptions;
+    }
+
+    /**
+     * Creates a ChromeDriver. Makes it headless if the -Dheadless flag is set.
+     * Can pass additional arguments with the -DchromeOptions flag, such as -DchromeOptions="start-maximized" to open all browser windows maximized.
+     * @return WebDriver ChromeDriver
+     */
+    private static WebDriver createChromeDriver() {
+        var chromeOptions = createChromeOptions();
     	WebDriverManager.chromedriver().setup();
     	return new ChromeDriver(chromeOptions);
     }
 
+    /**
+     * Creates a ChromeDriver configured with the Chromium browser. See {@link #createChromeDriver()} for supported options.
+     * @return WebDriver ChromeDriver
+     */
+    private static WebDriver createChromiumDriver() {
+        var chromeOptions = createChromeOptions();
+        WebDriverManager.chromiumdriver().setup();
+        return new ChromeDriver(chromeOptions);
+    }
 }

--- a/src/test/java/com/dougnoel/sentinel/webdrivers/WebDriverFactoryTest.java
+++ b/src/test/java/com/dougnoel/sentinel/webdrivers/WebDriverFactoryTest.java
@@ -15,6 +15,7 @@ public class WebDriverFactoryTest {
 	private static final String FIREFOX = "firefox";
 	private static final String GRIDURL = "gridUrl";
 	private static final String BROWSER = "browser";
+	private static final String CHROME_BROWSER_BINARY = "chromeBrowserBinary";
 	
 //	@BeforeClass
 //	public static void setUpBeforeAnyTestsAreRun() throws SentinelException {
@@ -29,8 +30,8 @@ public class WebDriverFactoryTest {
 		System.clearProperty(GRIDURL);
 		Configuration.clear(BROWSER);
 		System.clearProperty(BROWSER);
-		Configuration.clear("chromeBrowserBinary");
-		System.clearProperty("chromeBrowserBinary");
+		Configuration.clear(CHROME_BROWSER_BINARY);
+		System.clearProperty(CHROME_BROWSER_BINARY);
 		Configuration.clear("chromeOptions");
 		
 		Driver.quitAllDrivers();
@@ -48,6 +49,21 @@ public class WebDriverFactoryTest {
 	public void createChromeOptionsChromeDriver() {
 		Configuration.update("chromeOptions", "start-maximized");
 		WebDriverFactory.instantiateWebDriver();
+		PageManager.setPage("MockTestPage");
+		var js = (JavascriptExecutor)Driver.getWebDriver();
+		assertSame("Expecting window to be maximized.", "true", js.executeScript("return document.fullscreenEnabled").toString());
+	}
+
+	@Test
+	public void createChromiumDriver() {
+		Configuration.update("chromeOptions", "start-maximized");
+		Configuration.update(BROWSER, "chromium");
+		// We are assuming, for the sake of the unit tests, that chromium is installed using the Chocolately package
+		// manager, which installs the latest "stable" version of chromium for windows.
+		// `choco install chromium` installs the chromium binary in the following location.
+		Configuration.update(CHROME_BROWSER_BINARY, "C:/Program Files/Chromium/Application/chrome.exe");
+		var driver = WebDriverFactory.instantiateWebDriver();
+
 		PageManager.setPage("MockTestPage");
 		var js = (JavascriptExecutor)Driver.getWebDriver();
 		assertSame("Expecting window to be maximized.", "true", js.executeScript("return document.fullscreenEnabled").toString());


### PR DESCRIPTION
Adds support for the open source chromium browser.

We install chromium into the GitHub workflow using chocolately (viz.
choco install chromium). By default chromedriver looks for chrome to be
installed in a standard location, which chrome is, so we override the
location for which to look for chome.exe, which is the chromium binary.

Add a basic sanity unit test that ensures the chromium browser can be
launched and made fullscreen.