### PR TITLE
Modified has/has not attribute to return false on failure instead of exception

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/elements/Element.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/Element.java
@@ -730,7 +730,7 @@ public class Element {
 							ExpectedConditions.attributeToBeNotEmpty(element(), attribute)));
 		}
 		catch(TimeoutException timeout){
-			return true;
+			return false;
 		}
 
 	}

--- a/src/main/java/com/dougnoel/sentinel/elements/Element.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/Element.java
@@ -701,9 +701,14 @@ public class Element {
 	 * @return true if the attribute exists for the element; otherwise false
 	 */
 	public boolean hasAttribute(String attribute) {
-		return new WebDriverWait(driver(), Time.out().toSeconds(), Time.interval().toMillis())
-				.ignoring(StaleElementReferenceException.class)
-				.until(ExpectedConditions.attributeToBeNotEmpty(element(), attribute));
+		try{
+			return new WebDriverWait(driver(), Time.out().toSeconds(), Time.interval().toMillis())
+					.ignoring(StaleElementReferenceException.class)
+					.until(ExpectedConditions.attributeToBeNotEmpty(element(), attribute));
+		}
+		catch(TimeoutException timeout){
+			return false;
+		}
 	}
 
 	/**
@@ -718,10 +723,16 @@ public class Element {
 	 * @return true if the attribute does not exist for the element; otherwise false
 	 */
 	public boolean doesNotHaveAttribute(String attribute) {
-		return new WebDriverWait(driver(), Time.out().toSeconds(), Time.interval().toMillis())
-				.ignoring(StaleElementReferenceException.class)
-				.until(ExpectedConditions.not(
-						ExpectedConditions.attributeToBeNotEmpty(element(), attribute)));
+		try{
+			return new WebDriverWait(driver(), Time.out().toSeconds(), Time.interval().toMillis())
+					.ignoring(StaleElementReferenceException.class)
+					.until(ExpectedConditions.not(
+							ExpectedConditions.attributeToBeNotEmpty(element(), attribute)));
+		}
+		catch(TimeoutException timeout){
+			return true;
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
… than timeout exception to match up with expected behavior. This will allow better implementation of disabled element overrides where something akin to readonly may be used instead.