### PR TITLE
Tyler/documentation fix minor api changes

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/steps/APISteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/APISteps.java
@@ -94,8 +94,8 @@ public class APISteps {
      * </ul>
      * <p>
      *  
-	 * @param apiCallType
-	 * @param endpoint
+	 * @param apiCallType String the type of API call to make
+	 * @param endpoint String the endpoint to make the call to
 	 */
 	@When("^I send a (DELETE|GET|POST|PUT) request to the (.*?) endpoint$")
 	public void sendRequest(String apiCallType, String endpoint) {
@@ -154,7 +154,7 @@ public class APISteps {
 	 * @param matchType String use "contains" for a partial match otherwise it will be an exact match
 	 * @param text String the text to match
 	 */
-	@Then("^I validate the response( does not)? (has|have|contains?) the text \"([^\"]*)\"$")
+	@Then("^I validate the response( does not)? (has|have|contains?) the text (.*?)$")
     public void verifyResponseContains(String assertion, String matchType, String text) {
         boolean negate = !StringUtils.isEmpty(assertion);
         boolean partialMatch = matchType.contains("contain");

--- a/src/main/java/com/dougnoel/sentinel/steps/APISteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/APISteps.java
@@ -136,7 +136,11 @@ public class APISteps {
 				statusCode, responseCode, response.getResponse());
 		assertTrue(expectedResult, statusCode == responseCode);
 	}
-	
+
+	/**
+	 * Verify the response was received within a given time in seconds.
+	 * @param time double the number of seconds to verify the response time against
+	 */
 	@When("^I verify the response was received in less than (\\d{1,2}(?:[.,]\\d{1,4})?) seconds?$")
 	public void verifyResponseTime(double time) {
 		Duration timeLimit = Duration.ofMillis((long) (time * 1000));

--- a/src/main/java/com/dougnoel/sentinel/steps/APISteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/APISteps.java
@@ -152,6 +152,19 @@ public class APISteps {
 	}
 
 	/**
+	 * Validates text in an API response against previously stored text
+	 *
+	 * @param assertion String null to see if the text exists, "does not" to see if it is absent
+	 * @param matchType String use "contains" for a partial match otherwise it will be an exact match
+	 * @param key Key that the text to match is stored under
+	 */
+	@Then("^I validate the response( does not)? (has|have|contains?) the same text (?:entered|selected|used) for the (.*)$")
+	public void verifyResponseContainsStored(String assertion, String matchType, String key) {
+		String storedText = Configuration.toString(key);
+		verifyResponseContains(assertion, matchType, storedText);
+	}
+
+	/**
 	 * Validates text in an API response.
 	 * 
 	 * @param assertion String null to see if the text exists, "does not" to see if it is absent
@@ -196,4 +209,30 @@ public class APISteps {
 		APIManager.addHeader(name, value);
 	}
 
+	/**
+	 * Stores the current response body, code, or response time as a string using the given key
+	 *
+	 * @param responseSectionToStore String the portion of the response to store
+	 * @param key String the key to store the response under
+	 */
+	@When("^I save the response (body|code|time) as (.*?)$")
+	public void storeResponseValue(String responseSectionToStore, String key) {
+		String valueToStore = null;
+
+		switch(responseSectionToStore) {
+			case "body":
+				valueToStore = APIManager.getResponse().getResponse();
+				break;
+			case "code":
+				valueToStore = Integer.toString(APIManager.getResponse().getResponseCode());
+				break;
+			case "header":
+				valueToStore = Long.toString(APIManager.getResponse().getReponseTime().getSeconds());
+				break;
+			default:
+				break;
+		}
+
+		Configuration.update(key, valueToStore);
+	}
 }

--- a/src/main/java/com/dougnoel/sentinel/steps/APISteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/APISteps.java
@@ -210,29 +210,12 @@ public class APISteps {
 	}
 
 	/**
-	 * Stores the current response body, code, or response time as a string using the given key
+	 * Stores the current response body using the given key
 	 *
-	 * @param responseSectionToStore String the portion of the response to store
 	 * @param key String the key to store the response under
 	 */
-	@When("^I save the response (body|code|time) as (.*?)$")
-	public void storeResponseValue(String responseSectionToStore, String key) {
-		String valueToStore = null;
-
-		switch(responseSectionToStore) {
-			case "body":
-				valueToStore = APIManager.getResponse().getResponse();
-				break;
-			case "code":
-				valueToStore = Integer.toString(APIManager.getResponse().getResponseCode());
-				break;
-			case "header":
-				valueToStore = Long.toString(APIManager.getResponse().getReponseTime().getSeconds());
-				break;
-			default:
-				break;
-		}
-
-		Configuration.update(key, valueToStore);
+	@When("^I save the response body as (.*?)$")
+	public void storeResponseValue(String key) {
+		Configuration.update(key, APIManager.getResponse().getResponse());
 	}
 }

--- a/src/main/java/com/dougnoel/sentinel/system/FileManager.java
+++ b/src/main/java/com/dougnoel/sentinel/system/FileManager.java
@@ -204,10 +204,23 @@ public class FileManager {
 		return convertPathSeparators(Configuration.toString("imageDirectory", IMAGE_DIRECTORY) + File.separator + outputSubDir + File.separator + fileName);
 	}
 
+	/**
+	 * Takes a string constructed path, and replaces forward separators with the operating system agnostic File.separator.
+	 *
+	 * @param path String a constructed string path utilizing forward slashes
+	 * @return String a string using OS agnostic File.separator separators
+	 */
 	public static String convertPathSeparators(String path) {
 		return path.replace("/", File.separator);
 	}
 
+	/**
+	 * Performs sanitization on a string to remove all but alphanumeric characters, dashes, and periods.
+	 * Replaces said characters with underscores, resulting in a string which will not violate any system's special character restraints.
+	 *
+	 * @param toSanitize String the string to sanitize
+	 * @return String a string with all non alphanumeric, period, and dashes replaced with underscores
+	 */
 	public static String sanitizeString(String toSanitize) {
 		return toSanitize.replaceAll("[^a-zA-Z0-9\\.\\-]", "_");
 	}

--- a/src/test/java/features/89 API Testing.feature
+++ b/src/test/java/features/89 API Testing.feature
@@ -84,7 +84,8 @@ Feature: 89 API Testing
     Then I verify the response code equals 200
       And I validate the response contains the same text used for the previousResponseBody
       And I validate the response has the same text used for the previousResponseBody
-    When I load puppydata to use as the request body
-      And I send a POST request to the pet endpoint
+    When I add a status parameter with the value available
+      And I send a GET request to the pet/findByStatus endpoint
     Then I verify the response code equals 200
-      And I validate the response does not contain the same text used for the previousResponseBody
+      And I validate the response contains the same text used for the previousResponseBody
+      And I validate the response does not have the same text used for the previousResponseBody

--- a/src/test/java/features/89 API Testing.feature
+++ b/src/test/java/features/89 API Testing.feature
@@ -3,7 +3,7 @@
 Feature: 89 API Testing
   Tests using the Swagger Pet Store example API.
   https://petstore3.swagger.io/
-      
+
   @89A
   Scenario: 89A POST Swagger Test
     Given I use the API named Pet Store API
@@ -77,10 +77,10 @@ Feature: 89 API Testing
   @89G
   Scenario: 89G Storing and comparing against stored values
     Given I use the API named Pet Store API
-    When I GET record {test_id} from the pet endpoint
+    When I GET record 12 from the pet endpoint
     Then I verify the response code equals 200
     When I save the response body as previousResponseBody
-      And I GET record {test_id} from the pet endpoint
+      And I GET record 12 from the pet endpoint
     Then I verify the response code equals 200
       And I validate the response contains the same text used for the previousResponseBody
       And I validate the response has the same text used for the previousResponseBody

--- a/src/test/java/features/89 API Testing.feature
+++ b/src/test/java/features/89 API Testing.feature
@@ -73,3 +73,18 @@ Feature: 89 API Testing
     Then I verify the response code equals 200
     When I GET record 10 from the pet endpoint
     Then I verify the response code equals 404
+
+  @89G
+  Scenario: 89G Storing and comparing against stored values
+    Given I use the API named Pet Store API
+    When I GET record {test_id} from the pet endpoint
+    Then I verify the response code equals 200
+    When I save the response body as previousResponseBody
+      And I GET record {test_id} from the pet endpoint
+    Then I verify the response code equals 200
+      And I validate the response contains the same text used for the previousResponseBody
+      And I validate the response has the same text used for the previousResponseBody
+    When I load puppydata to use as the request body
+      And I send a POST request to the pet endpoint
+    Then I verify the response code equals 200
+      And I validate the response does not contain the same text used for the previousResponseBody


### PR DESCRIPTION
Adds some storage and comparison of a response body against stored values.
Fixes some missing documentation in two locations.
Changed a step as using quotations was preventing proper checking of values (values being compared often contain quotations themselves).
Adjusted tests accordingly.