### PR TITLE
Add table verification step. Add screenshots for failing tests

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/elements/tables/Table.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/tables/Table.java
@@ -1,11 +1,13 @@
 package com.dougnoel.sentinel.elements.tables;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.dougnoel.sentinel.steps.BaseSteps;
 import com.dougnoel.sentinel.webdrivers.WebDriverFactory;
@@ -972,5 +974,24 @@ public class Table extends Element {
 			log.error(errorMsg);
 			return false;
 		}
+	}
+
+	/**
+	 * Compares all values in the given column to the given referenceNumber, using the given comparisonType.
+	 * Converts all values in the given column to double.
+	 * Valid comparisonType values = {"less than", "greater than"}. Any other value of comparisonType will make this method perform an "equals" comparison.
+	 * @param columnHeader String name of the column
+	 * @param comparisonType String type of comparison to perform. Valid values are "less than", "greater than". Any other string will force an "equals" comparison.
+	 * @param referenceNumber double the number to compare against.
+	 * @return boolean true if all values in the column satisfy the given comparison. false otherwise.
+	 */
+	public boolean verifyNumericValuesInWholeColumn(String columnHeader, String comparisonType, double referenceNumber){
+		var allColumnData = getAllCellDataForColumn(columnHeader).stream().map(Double::parseDouble).collect(Collectors.toList());
+		if(comparisonType.equalsIgnoreCase("less than"))
+			return allColumnData.stream().allMatch(cellValue -> cellValue < referenceNumber);
+		else if(comparisonType.equalsIgnoreCase("greater than"))
+			return allColumnData.stream().allMatch(cellValue -> cellValue > referenceNumber);
+		else
+			return allColumnData.stream().allMatch(cellValue -> cellValue == referenceNumber);
 	}
 }

--- a/src/main/java/com/dougnoel/sentinel/steps/TableVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/TableVerificationSteps.java
@@ -418,4 +418,23 @@ public class TableVerificationSteps {
         log.trace(expectedResult);
         Assert.assertTrue(expectedResult, table.waitForSpecificCellToContain((int)Time.longProcessTimeout().toSeconds(), columnName, rowIndex, textToMatch, partialMatch, negate));
     }
+
+    /**
+     * Verifies all values in the given column are in the given state relative to the given referenceNumber, using the given comparisonType.
+     * Assumes all values in the given column are numeric, and able to be converted to double.
+     * @param columnName String name of the column in the table
+     * @param tableName String name of the table element
+     * @param comparisonType String type of comparison to perform. Options: "less than", "greater than", "equal to".
+     * @param referenceNumber String the number to compare the column values to. Needs to be a numeric value, able to be converted to a double.
+     * @throws Exception if the assertion fails or the table method throws an exception.
+     */
+    @Then("^I verify all values in the (.*) column in the (.*) are (less than|greater than|equal to) (.*?)$")
+    public static void verifyAllNumericValuesInColumn(String columnName, String tableName, String comparisonType, String referenceNumber) throws Exception {
+        Table table = getElementAsTable(tableName);
+        var expectedResult = SentinelStringUtils.format(
+                "Expected all values in the {} column of the {} to be {} {}.",
+                columnName, tableName, comparisonType, referenceNumber);
+        log.trace(expectedResult);
+        assertTrue(expectedResult, table, () -> table.verifyNumericValuesInWholeColumn(columnName, comparisonType, Double.parseDouble(referenceNumber)));
+    }
 }

--- a/src/test/java/hooks/SentinelHooks.java
+++ b/src/test/java/hooks/SentinelHooks.java
@@ -1,0 +1,19 @@
+package hooks;
+
+import com.dougnoel.sentinel.webdrivers.Driver;
+import io.cucumber.java.After;
+import io.cucumber.java.Scenario;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+
+public class SentinelHooks {
+
+    @After
+    public static void tearDown(Scenario scenario) {
+        //Take screenshot and attach to report if scenario has failed
+        if(scenario.isFailed()) {
+            final byte[] screenshot = ((TakesScreenshot) Driver.getWebDriver()).getScreenshotAs(OutputType.BYTES);
+            scenario.attach(screenshot, "image/png", scenario.getName());
+        }
+    }
+}

--- a/src/test/java/tests/SentinelTests.java
+++ b/src/test/java/tests/SentinelTests.java
@@ -12,11 +12,10 @@ import com.dougnoel.sentinel.webdrivers.Driver;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import junit.runner.Version;
-
 @RunWith(Cucumber.class)
 @CucumberOptions(monochrome = true
 	, features = "src/test/java/features"
-	, glue = { "com.dougnoel.sentinel.steps", "steps" }
+	, glue = { "com.dougnoel.sentinel.steps", "steps", "hooks" }
 	, plugin = {"json:target/cucumber.json",
 			"com.aventstack.extentreports.cucumber.adapter.ExtentCucumberAdapter:"}
 )

--- a/src/test/resources/extent.properties
+++ b/src/test/resources/extent.properties
@@ -3,4 +3,5 @@ extent.reporter.html.out=reports/extent-cucumber-report.html
 extent.reporter.pdf.start=true
 extent.reporter.pdf.out=reports/ExtentPdf.pdf
 
-screenshot.dir=reports/
+screenshot.dir=reports/screenshots/
+screenshot.rel.path=./screenshots/


### PR DESCRIPTION
- Address #491, adding verification step for numeric values in table column.
- Add hooks file to take a screenshot (only of the application window) if the test fails and attach it to the report.