### PR TITLE
making download tests fail faster

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/system/DownloadManager.java
+++ b/src/main/java/com/dougnoel/sentinel/system/DownloadManager.java
@@ -97,7 +97,7 @@ public class DownloadManager {
         String downloadedFileName = null;
         var valid = true;
         
-        long timeOut = Time.longProcessTimeout().toSeconds();
+        long timeOut = Time.out().toSeconds();
         long loopTime = Time.loopInterval().toMillis();
         var downloadFolderPath = Paths.get(downloadDir);
         var watchService = FileSystems.getDefault().newWatchService();


### PR DESCRIPTION
per Doug's ask - reverting the timeout so that the tests fail faster because it seems the length of timeout isnt the issue?