### PR TITLE
551 zip file count verification

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/elements/WindowsElement.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/WindowsElement.java
@@ -236,6 +236,45 @@ public class WindowsElement extends Element {
 	}
 
 	/**
+	 * <i><b>NOTE:</b> In addition to the documentation seen below, if the "color" attribute is used on a windows element it will perform a special return
+	 * as the "color" attribute does not properly exist as an attribute in windows. Instead, it is calculated in Sentinel using a screenshot and offset.</i>
+	 * <br><br>
+	 * <p>
+	 * From selenium's javadoc: <br>
+	 * Get the value of the given attribute of the element. Will return the current value,
+	 * even if this has been modified after the page has been loaded. <br>
+	 * More exactly, this method will return the value of the property with the given name,
+	 * if it exists. If it does not, then the value of the attribute with the given name is returned.
+	 * If neither exists, null is returned. <br>
+	 * The "style" attribute is converted as best can be to a text representation with a trailingsemi-colon. <br>
+	 * The following are deemed to be "boolean" attributes, and will return either "true" or null:
+	 * async, autofocus, autoplay, checked, compact, complete, controls, declare, defaultchecked,
+	 * defaultselected, defer, disabled, draggable, ended, formnovalidate, hidden, indeterminate,
+	 * iscontenteditable, ismap, itemscope, loop, multiple, muted, nohref, noresize, noshade,
+	 * novalidate, nowrap, open, paused, pubdate, readonly, required, reversed, scoped, seamless,
+	 * seeking, selected, truespeed, willvalidate
+	 * <br>
+	 * Finally, the following commonly mis-capitalized attribute/property names are evaluated as expected: <br>
+	 * •If the given name is "class", the "className" property is returned. <br>
+	 * •If the given name is "readonly", the "readOnly" property is returned.
+	 *
+	 * Note: The reason for this behavior is that users frequently confuse attributes and properties. If you need to do something more precise, e.g., refer to an attribute even when aproperty of the same name exists, then you should evaluate Javascript to obtain the resultyou desire.
+	 * </p>
+	 *
+	 *
+	 * Gets the value of the given attribute on this element.
+	 * @param attribute String name of the attribute to get the value of
+	 * @return String the value of the given attribute, or null if it is not set.
+	 */
+	@Override
+	public String getAttribute(String attribute) {
+		if (attribute.equalsIgnoreCase("color")) {
+			return getColorAtOffset().asHex();
+		}
+		return super.getAttribute(attribute);
+	}
+
+	/**
 	 * Returns a screenshot File of the current element.
 	 *
 	 * @return File a screenshot of the current element

--- a/src/main/java/com/dougnoel/sentinel/steps/DownloadVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/DownloadVerificationSteps.java
@@ -194,7 +194,7 @@ public class DownloadVerificationSteps {
 	 * <li>I verify the most recently downloaded zip file <i><b>does not</b></i> contain <i><b>any</b></i> files <i><b>containing the name tabl.html</b></i></li>
 	 * <li>I verify the most recently downloaded zip file contains 0 files <i><b>containing the name e.htmL</b></i></li>
 	 * </ul>
-	 * <p>
+	 * </p>
 	 *
 	 * @param assertion String " does not" for a negative check, otherwise positive check.
 	 * @param expectedFileCount String the number of files we expect. 'Any' indicates that it will check for a count above 0.

--- a/src/main/java/com/dougnoel/sentinel/steps/DownloadVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/DownloadVerificationSteps.java
@@ -148,28 +148,34 @@ public class DownloadVerificationSteps {
 	/**
 	 * Looks inside the most recently downloaded zip file and asserts that it does or does not contain a file with the given extension.
 	 * This method can find files in subdirectories inside the zip, but not within nested zip files.
-	 * <br><br>
-	 * Behaves the same as the step "I verify the most recently downloaded zip file contains <i><b>any</b></i> files <i>with the extension <b>[EXTENSION]</b></i>"
-	 * <br>
+	 * <p>This method is <b>case insensitive</b> for file extension.</p>
+	 * <p>
+	 * Will behave the same as the steps:
+	 * <ul>
+	 * <li>I verify the most recently downloaded zip file contains <i><b>any</b></i> files <i>with the extension <b>zip</b></i></li>
+	 * <li>I verify the most recently downloaded zip file <i><b>does not</b></i> contain <i><b>any</b></i> files <i>with the extension <b>pDf</b></i></li>
+	 * </ul>
+	 * </p>
 	 * @param assertion String " does not" for a negative check, otherwise positive check
 	 * @param expectedFileType String the file extension to check for.
 	 */
 	@Then("^I verify the most recently downloaded zip file( does not)? contains? a file with the extension (.*?)$")
 	public static void verifyFileContentsOfZip(String assertion, String expectedFileType) throws IOException {
-		verifyZipFileCount(assertion, "any", expectedFileType);
+		verifyZipContentsFileCount(assertion, "any", expectedFileType);
 	}
 
 	/**
 	 * Looks inside the most recently downloaded zip file and asserts that it does or does not contain a give number of files
 	 * with an optionally specified extension.
-	 * This method can find files in subdirectories inside the zip, but not within nested zip files.
+	 * <p>This method can find files in subdirectories inside the zip, but not within nested zip files.</p>
+	 * <p>This method is <b>case insensitive</b> for file extension.</p>
 	 *
 	 * <p>
 	 * <br><b>Gherkin Example:</b><br>
 	 * <ul>
-	 * <li>I verify the most recently downloaded zip file <i><b>does not</b></i> contain <i><b>any</b></i> files <i>with the extension <b>pdf</b></i></li>
+	 * <li>I verify the most recently downloaded zip file <i><b>does not</b></i> contain <i><b>any</b></i> files <i>with the extension <b>pDf</b></i></li>
 	 * <li>I verify the most recently downloaded zip file <i><b>does not</b></i> contain <i><b>any</b></i> files <i>with the extension <b>csv</b></i></li>
-	 * <li>I verify the most recently downloaded zip file contains <i><b>any</b></i> files <i>with the extension <b>txt</b></i></li>
+	 * <li>I verify the most recently downloaded zip file contains <i><b>any</b></i> files <i>with the extension <b>txT</b></i></li>
 	 * <li>I verify the most recently downloaded zip file contains <i><b>1</b></i> file <i>with the extension <b>csv</b></i></li>
 	 * <li>I verify the most recently downloaded zip file contains <i><b>10</b></i> files</li>
 	 * <li>I verify the most recently downloaded zip file <i><b>does not</b></i> contain <i><b>11</b></i> files</li>
@@ -182,7 +188,7 @@ public class DownloadVerificationSteps {
 	 * @param expectedFileType String the optional file extension to limit the check to.
 	 */
 	@Then("^I verify the most recently downloaded zip file( does not)? contains? (\\d+|any) files?(?: with the extension (.*?))?$")
-	public static void verifyZipFileCount(String assertion, String expectedFileCount, String expectedFileType) throws IOException {
+	public static void verifyZipContentsFileCount(String assertion, String expectedFileCount, String expectedFileType) throws IOException {
 		Path mostRecentFile = DownloadManager.getMostRecentDownloadPath();
 		List<String> fileContent;
 		long expectedNumOfFiles = 0;
@@ -198,7 +204,7 @@ public class DownloadVerificationSteps {
 			fileContent = zip.getFileNames();
 			long filesFound;
 			if(expectedFileType != null) {
-				filesFound = fileContent.stream().filter(fileName -> StringUtils.endsWith(fileName, expectedFileType)).count();
+				filesFound = fileContent.stream().filter(fileName -> StringUtils.endsWith(fileName.toLowerCase(), expectedFileType.toLowerCase())).count();
 			}
 			else
 				filesFound = zip.getFileNames().size();

--- a/src/main/java/com/dougnoel/sentinel/steps/DownloadVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/DownloadVerificationSteps.java
@@ -149,13 +149,13 @@ public class DownloadVerificationSteps {
 	 * Looks inside the most recently downloaded zip file and asserts that it does or does not contain a file with the given extension.
 	 * This method can find files in subdirectories inside the zip, but not within nested zip files.
 	 * <p>This method is <b>case insensitive</b> for file extension.</p>
-	 * <p>
-	 * Will behave the same as the steps:
+	 *
+	 * <p>Will behave the same as the steps:</p>
 	 * <ul>
 	 * <li>I verify the most recently downloaded zip file contains <i><b>any</b></i> files <i>with the extension <b>zip</b></i></li>
 	 * <li>I verify the most recently downloaded zip file <i><b>does not</b></i> contain <i><b>any</b></i> files <i>with the extension <b>pDf</b></i></li>
 	 * </ul>
-	 * </p>
+	 *
 	 * @param assertion String " does not" for a negative check, otherwise positive check
 	 * @param expectedFileType String the file extension to check for.
 	 */
@@ -171,7 +171,6 @@ public class DownloadVerificationSteps {
 	 * <p>This method is <b>case insensitive</b> for file extension.</p>
 	 * <p>This method is <b>case sensitive</b> and <b>partial match</b> for text.</p>
 	 *
-	 * <p>
 	 * <br><b>Gherkin Example:</b><br>
 	 * <br>Extensions:
 	 * <ul>
@@ -194,7 +193,6 @@ public class DownloadVerificationSteps {
 	 * <li>I verify the most recently downloaded zip file <i><b>does not</b></i> contain <i><b>any</b></i> files <i><b>containing the name tabl.html</b></i></li>
 	 * <li>I verify the most recently downloaded zip file contains 0 files <i><b>containing the name e.htmL</b></i></li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param assertion String " does not" for a negative check, otherwise positive check.
 	 * @param expectedFileCount String the number of files we expect. 'Any' indicates that it will check for a count above 0.

--- a/src/main/java/com/dougnoel/sentinel/steps/DownloadVerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/DownloadVerificationSteps.java
@@ -235,8 +235,8 @@ public class DownloadVerificationSteps {
 			String message = SentinelStringUtils.format("Unable to open most recently downloaded file as zip file. Most recently downloaded file path {}", mostRecentFile);
 			throw new IOException(message, ioe);
 		}
-		assertEquals(SentinelStringUtils.format("Expected zip file to {}contain {} files with extension {}. Zip file location: {} Files in zip: {}",
-						(negate ? "not ": ""), expectedFileCount, expectedFileTypeOrPartialName, mostRecentFile, StringUtils.join(fileContent, ", ")),
+		assertEquals(SentinelStringUtils.format("Expected zip file to {}contain {} files {} {}. Zip file location: {} Files in zip: {}",
+						(negate ? "not ": ""), expectedFileCount, extensionOrName, expectedFileTypeOrPartialName, mostRecentFile, StringUtils.join(fileContent, ", ")),
 				!negate, result);
 	}
 }

--- a/src/test/java/features/239 Initial WinAppDriver Implementation.feature
+++ b/src/test/java/features/239 Initial WinAppDriver Implementation.feature
@@ -20,8 +20,8 @@ Feature: 239 Implement WinAppDriver to automate windows
     Given I switch to the Notepad App
     When I click the Text Editor field
     Then I verify the Text Editor field with the attribute color has the value #FFFFFF
-    When I hover the file menu dropdown
-      And I wait 2 seconds
+    When I click the Text Editor field
+      And I hover the file menu dropdown
     Then I verify the file menu dropdown with the attribute color has the value #E5F3FF
 
   @239D

--- a/src/test/java/features/239 Initial WinAppDriver Implementation.feature
+++ b/src/test/java/features/239 Initial WinAppDriver Implementation.feature
@@ -21,6 +21,7 @@ Feature: 239 Implement WinAppDriver to automate windows
     When I click the Text Editor field
     Then I verify the Text Editor field with the attribute color has the value #FFFFFF
     When I hover the file menu dropdown
+      And I wait 1 second
     Then I verify the file menu dropdown with the attribute color has the value #E5F3FF
 
   @239D

--- a/src/test/java/features/239 Initial WinAppDriver Implementation.feature
+++ b/src/test/java/features/239 Initial WinAppDriver Implementation.feature
@@ -21,7 +21,7 @@ Feature: 239 Implement WinAppDriver to automate windows
     When I click the Text Editor field
     Then I verify the Text Editor field with the attribute color has the value #FFFFFF
     When I hover the file menu dropdown
-      And I wait 1 second
+      And I wait 2 seconds
     Then I verify the file menu dropdown with the attribute color has the value #E5F3FF
 
   @239D

--- a/src/test/java/features/327 Download Verification Steps.feature
+++ b/src/test/java/features/327 Download Verification Steps.feature
@@ -40,21 +40,21 @@ Feature: Download Verification Steps
   @551A
   Scenario: Download zip and verify it contains 1 pdf
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
-      And I verify the most recently downloaded zip file contains 1 file with the extension pdf
+      And I verify the most recently downloaded zip file contains 1 file with extension pdf
 
   @551B
   Scenario: Download zip and verify it contains no files with png
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
-      And I verify the most recently downloaded zip file contains 0 files with the extension png
-      And I verify the most recently downloaded zip file does not contains 1 file with the extension png
-      And I verify the most recently downloaded zip file does not contain any files with the extension png
+      And I verify the most recently downloaded zip file contains 0 files with extension png
+      And I verify the most recently downloaded zip file does not contains 1 file with extension png
+      And I verify the most recently downloaded zip file does not contain any files with extension png
 
   @551C
   Scenario: Download zip and verify it does not contain 5 pdfs, contains 1 pdf, and contains 1 html
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
-    And I verify the most recently downloaded zip file does not contain 5 files with the extension pdf
-    And I verify the most recently downloaded zip file contains 1 file with the extension pdF
-    And I verify the most recently downloaded zip file contains 1 file with the extension html
+    And I verify the most recently downloaded zip file does not contain 5 files with extension pdf
+    And I verify the most recently downloaded zip file contains 1 file with extension pdF
+    And I verify the most recently downloaded zip file contains 1 file with extension html
 
   @551D
   Scenario: Download zip and verify it contains 2 files of any extension
@@ -70,3 +70,15 @@ Feature: Download Verification Steps
   Scenario: Download zip and verify it contains any files
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
       And I verify the most recently downloaded zip file contains any files
+
+  @551F
+  Scenario: Partial match support for checking files by name in a zip file
+    Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
+      And I verify the most recently downloaded zip file contains any files containing the name TestPDF.pdf
+      And I verify the most recently downloaded zip file contains 1 file containing the name TestPDF
+      And I verify the most recently downloaded zip file contains any file containing the name table.html
+      And I verify the most recently downloaded zip file contains 1 files containing the name .html
+      And I verify the most recently downloaded zip file does not contain any files containing the name TestPdF.pdf
+      And I verify the most recently downloaded zip file does not contain 1 files containing the name testpdf
+      And I verify the most recently downloaded zip file does not contain any files containing the name tabl.html
+      And I verify the most recently downloaded zip file contains 0 files containing the name e.htmL

--- a/src/test/java/features/327 Download Verification Steps.feature
+++ b/src/test/java/features/327 Download Verification Steps.feature
@@ -1,6 +1,6 @@
 #author: sampacos, tylerbouchard
 
-@327
+@327 @551
 Feature: Download Verification Steps
   Unit tests for the DownloadVerificationSteps
 
@@ -37,26 +37,26 @@ Feature: Download Verification Steps
       And I verify the filename contains today's date
       And I verify the filename contains today's date formatted as _HH_
 
-  @327E
+  @551A
   Scenario: Download zip and verify it contains 1 pdf
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
       And I verify the most recently downloaded zip file contains 1 file with the extension pdf
 
-  @327F
+  @551B
   Scenario: Download zip and verify it contains no files with png
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
       And I verify the most recently downloaded zip file contains 0 files with the extension png
       And I verify the most recently downloaded zip file does not contains 1 file with the extension png
       And I verify the most recently downloaded zip file does not contain any files with the extension png
 
-  @327G
+  @551C
   Scenario: Download zip and verify it does not contain 5 pdfs, contains 1 pdf, and contains 1 html
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
     And I verify the most recently downloaded zip file does not contain 5 files with the extension pdf
     And I verify the most recently downloaded zip file contains 1 file with the extension pdf
     And I verify the most recently downloaded zip file contains 1 file with the extension html
 
-  @327H
+  @551D
   Scenario: Download zip and verify it contains 2 files of any extension
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
       And I verify the most recently downloaded zip file contains 2 files
@@ -66,7 +66,7 @@ Feature: Download Verification Steps
       And I verify the most recently downloaded zip file does not contain 00 files
       And I verify the most recently downloaded zip file does not contain 1 file
 
-  @327I
+  @551E
   Scenario: Download zip and verify it contains any files
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
       And I verify the most recently downloaded zip file contains any files

--- a/src/test/java/features/327 Download Verification Steps.feature
+++ b/src/test/java/features/327 Download Verification Steps.feature
@@ -53,7 +53,7 @@ Feature: Download Verification Steps
   Scenario: Download zip and verify it does not contain 5 pdfs, contains 1 pdf, and contains 1 html
     Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
     And I verify the most recently downloaded zip file does not contain 5 files with the extension pdf
-    And I verify the most recently downloaded zip file contains 1 file with the extension pdf
+    And I verify the most recently downloaded zip file contains 1 file with the extension pdF
     And I verify the most recently downloaded zip file contains 1 file with the extension html
 
   @551D

--- a/src/test/java/features/327 Download Verification Steps.feature
+++ b/src/test/java/features/327 Download Verification Steps.feature
@@ -36,3 +36,37 @@ Feature: Download Verification Steps
     Then I verify that by clicking the text file download link a new file is downloaded with the extension txt
       And I verify the filename contains today's date
       And I verify the filename contains today's date formatted as _HH_
+
+  @327E
+  Scenario: Download zip and verify it contains 1 pdf
+    Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
+      And I verify the most recently downloaded zip file contains 1 file with the extension pdf
+
+  @327F
+  Scenario: Download zip and verify it contains no files with png
+    Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
+      And I verify the most recently downloaded zip file contains 0 files with the extension png
+      And I verify the most recently downloaded zip file does not contains 1 file with the extension png
+      And I verify the most recently downloaded zip file does not contain any files with the extension png
+
+  @327G
+  Scenario: Download zip and verify it does not contain 5 pdfs, contains 1 pdf, and contains 1 html
+    Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
+    And I verify the most recently downloaded zip file does not contain 5 files with the extension pdf
+    And I verify the most recently downloaded zip file contains 1 file with the extension pdf
+    And I verify the most recently downloaded zip file contains 1 file with the extension html
+
+  @327H
+  Scenario: Download zip and verify it contains 2 files of any extension
+    Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
+      And I verify the most recently downloaded zip file contains 2 files
+      And I verify the most recently downloaded zip file contains 02 files
+      And I verify the most recently downloaded zip file does not contain 3 files
+      And I verify the most recently downloaded zip file does not contain 0 files
+      And I verify the most recently downloaded zip file does not contain 00 files
+      And I verify the most recently downloaded zip file does not contain 1 file
+
+  @327I
+  Scenario: Download zip and verify it contains any files
+    Then I verify that by clicking the zip download link a new file is downloaded with the extension zip
+      And I verify the most recently downloaded zip file contains any files


### PR DESCRIPTION
Adds a new step which can take an extension optionally, and a file count.

File count can be any integer.
"0" is valid as an optional way of checking for 0 files. Otherwise "any" can be utilized for "above 0" or none for does not.
Uses file content stream filtering to filter down the extensions, or gets the flat file names size otherwise.

Only takes 0+, only whole numbers or "any" for the count of files. Any extension is allowed, but it must end with the given extension.

Old step "^I verify the most recently downloaded zip file( does not)? contains? a file with the extension (.*?)$" has been updated to use the new step with the "any" call, and has had its documentation updated that the steps are equivalent and will behave the same.

Also supports case-insensitive extension or case sensitive partial name contains. Good for testing for partially randomly generated names like reports with a date-time stamp. Extension is case insensitive as the OS doesn't care about casing. Naming is case sensitive.