### PR TITLE
553 - Modify does not exist to allow for doesNotExist() in custom steps while retaining the windows functionality fix

### DIFF
--- a/src/main/java/com/dougnoel/sentinel/elements/Element.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/Element.java
@@ -619,7 +619,8 @@ public class Element {
 	 * This should be used when you expect an element to not be present and do not want
 	 * to slow down your tests waiting for the normal timeout time to expire.
 	 *
-	 * Defaults to assuming iframes exist.
+	 * Defaults to assuming iframes will never exist for windows elements, and may exist for web elements.
+	 * @return boolean true if the element cannot be found, false if it is found
 	 */
 	public boolean doesNotExist() {
 		return doesNotExist(true);

--- a/src/main/java/com/dougnoel/sentinel/elements/Element.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/Element.java
@@ -612,7 +612,19 @@ public class Element {
 			return false;
 		}
 	}
-	
+
+	/**
+	 * Returns true if an element is neither found nor displayed otherwise false.
+	 * Will poll every selector on the page object in a loop until the timeout is reached.
+	 * This should be used when you expect an element to not be present and do not want
+	 * to slow down your tests waiting for the normal timeout time to expire.
+	 *
+	 * Defaults to assuming iframes exist.
+	 */
+	public boolean doesNotExist() {
+		return doesNotExist(true);
+	}
+
 	/**
 	 * Returns true if an element is neither found nor displayed otherwise false.
 	 * Will poll every selector on the page object in a loop until the timeout is reached.

--- a/src/main/java/com/dougnoel/sentinel/elements/Element.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/Element.java
@@ -630,9 +630,10 @@ public class Element {
 	 * Will poll every selector on the page object in a loop until the timeout is reached.
 	 * This should be used when you expect an element to not be present and do not want
 	 * to slow down your tests waiting for the normal timeout time to expire.
+	 * @param hasIframes True if we expect to process iframes, false if we don't expect iframes
 	 * @return boolean true if the element cannot be found, false if it is found
 	 */
-	public boolean doesNotExist(boolean hasIframes) {
+	protected boolean doesNotExist(boolean hasIframes) {
 		long searchTime = Time.out().getSeconds() * 1000;
 		long startTime = System.currentTimeMillis(); // fetch starting time
 		while ((System.currentTimeMillis() - startTime) < searchTime) {

--- a/src/main/java/com/dougnoel/sentinel/elements/WindowsElement.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/WindowsElement.java
@@ -38,6 +38,19 @@ public class WindowsElement extends Element {
 	}
 
 	/**
+	 * Returns true if an element is neither found nor displayed otherwise false.
+	 * Will poll every selector on the page object in a loop until the timeout is reached.
+	 * This should be used when you expect an element to not be present and do not want
+	 * to slow down your tests waiting for the normal timeout time to expire.
+	 *
+	 * Defaults to assuming iframes do not exist for windows.
+	 */
+	@Override
+	public boolean doesNotExist() {
+		return doesNotExist(false);
+	}
+
+	/**
 	 * Returns the Selenium WebElement if it can be found on the current page.
 	 * Provides late binding for elements so that the driver does not look for them
 	 * until they are called, at which point the driver should be on the correct

--- a/src/main/java/com/dougnoel/sentinel/elements/WindowsElement.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/WindowsElement.java
@@ -47,7 +47,7 @@ public class WindowsElement extends Element {
 	 */
 	@Override
 	public boolean doesNotExist() {
-		return doesNotExist(false);
+		return super.doesNotExist(false);
 	}
 
 	/**

--- a/src/main/java/com/dougnoel/sentinel/elements/WindowsElement.java
+++ b/src/main/java/com/dougnoel/sentinel/elements/WindowsElement.java
@@ -43,7 +43,8 @@ public class WindowsElement extends Element {
 	 * This should be used when you expect an element to not be present and do not want
 	 * to slow down your tests waiting for the normal timeout time to expire.
 	 *
-	 * Defaults to assuming iframes do not exist for windows.
+	 * Defaults to assuming iframes will never exist for windows elements, and may exist for web elements.
+	 * @return boolean true if the element cannot be found, false if it is found
 	 */
 	@Override
 	public boolean doesNotExist() {

--- a/src/main/java/com/dougnoel/sentinel/steps/VerificationSteps.java
+++ b/src/main/java/com/dougnoel/sentinel/steps/VerificationSteps.java
@@ -146,7 +146,7 @@ public class VerificationSteps {
         String expectedResult = SentinelStringUtils.format("Expected the element {} to {}exist.",
                 elementName, (negate ? "not " : ""));
         if (negate) {
-            assertTrue(expectedResult, getElement(elementName).doesNotExist(false));
+            assertTrue(expectedResult, getElement(elementName).doesNotExist());
         } else {
             assertTrue(expectedResult, getElement(elementName).isDisplayed());
         }

--- a/src/test/java/com/dougnoel/sentinel/elements/WindowsElementTests.java
+++ b/src/test/java/com/dougnoel/sentinel/elements/WindowsElementTests.java
@@ -54,11 +54,11 @@ public class WindowsElementTests {
 
 	@Test()
 	public void doesNotExistForElementThatExists(){
-		assertFalse("Expected element to exist.", getElement("file menu dropdown").doesNotExist(false));
+		assertFalse("Expected element to exist.", getElement("file menu dropdown").doesNotExist());
 	}
 
 	@Test
 	public void doesNotExistOnBadElement() {
-		assertTrue("Expecting element to not exist.", getElement("generic_id").doesNotExist(false));
+		assertTrue("Expecting element to not exist.", getElement("generic_id").doesNotExist());
 	}
 }


### PR DESCRIPTION
This is an unseen issue where if a user had already created custom steps directly calling doesNotExist they would need to update it with a boolean. This method of overload will allow those to keep working while still adding the adjustment to windows without requiring duplicated code.